### PR TITLE
feat: unify managed PR detection across webhook and catch-up

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,6 @@ state/
 .worktrees/
 git-cache/
 work/
+.githooks/
 .env
 .DS_Store

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -22,6 +22,6 @@ export default [
     }
   },
   {
-    ignores: ["dist/**", ".worktrees/**", "git-cache/**", "logs/**", "reports/**", "state/**", "work/**"]
+    ignores: ["dist/**", ".githooks/**", ".worktrees/**", "git-cache/**", "logs/**", "reports/**", "state/**", "work/**"]
   }
 ];

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test:unit": "vitest run ./tests/unit",
     "test:e2e": "vitest run ./tests/e2e",
     "dev": "tsx src/cli.ts",
-    "prepare": "simple-git-hooks"
+    "prepare": "node scripts/setup-git-hooks.mjs && simple-git-hooks"
   },
   "dependencies": {
     "@octokit/auth-app": "^7.2.2",

--- a/scripts/setup-git-hooks.mjs
+++ b/scripts/setup-git-hooks.mjs
@@ -1,0 +1,40 @@
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+
+function tryRunGit(args, options = {}) {
+  try {
+    const stdout = execFileSync("git", args, {
+      ...options,
+      stdio: ["ignore", "pipe", "ignore"],
+      encoding: "utf8"
+    });
+    return { ok: true, stdout: stdout.trim() };
+  } catch {
+    return { ok: false, stdout: "" };
+  }
+}
+
+function ensureHooksDirExists(hooksPath) {
+  if (!hooksPath || path.isAbsolute(hooksPath)) return;
+  fs.mkdirSync(path.join(process.cwd(), hooksPath), { recursive: true });
+}
+
+const isWorkTree = tryRunGit(["rev-parse", "--is-inside-work-tree"]);
+if (!isWorkTree.ok || isWorkTree.stdout !== "true") {
+  process.exit(0);
+}
+
+const currentHooksPath = tryRunGit(["config", "--local", "--get", "core.hooksPath"]);
+if (!currentHooksPath.ok || currentHooksPath.stdout.length === 0) {
+  const setResult = tryRunGit(["config", "--local", "core.hooksPath", ".githooks"]);
+  if (!setResult.ok) {
+    process.exit(0);
+  }
+}
+
+const effectiveHooksPath = tryRunGit(["config", "--local", "--get", "core.hooksPath"]);
+if (effectiveHooksPath.ok) {
+  ensureHooksDirExists(effectiveHooksPath.stdout);
+}

--- a/src/managed-pr-review-catchup.ts
+++ b/src/managed-pr-review-catchup.ts
@@ -1,0 +1,167 @@
+import type { AgentRunnerConfig } from "./config.js";
+import type { GitHubClient, IssueInfo, RepoInfo } from "./github.js";
+import { summarizeLatestReviews } from "./pr-review-automation.js";
+import { enqueueReviewTask, resolveReviewQueuePath } from "./review-queue.js";
+import { listManagedPullRequests, resolveManagedPullRequestsStatePath } from "./managed-pull-requests.js";
+import { ensureManagedPullRequestRecorded, isManagedPullRequestIssue } from "./managed-pr.js";
+
+export async function enqueueManagedPullRequestReviewFollowups(options: {
+  client: GitHubClient;
+  config: AgentRunnerConfig;
+  maxEntries: number;
+  dryRun: boolean;
+  onLog?: (level: "info" | "warn" | "error", message: string, data?: Record<string, unknown>) => void;
+}): Promise<number> {
+  const limit = Math.max(0, Math.floor(options.maxEntries));
+  if (limit <= 0) {
+    return 0;
+  }
+  if (!options.config.idle?.enabled) {
+    return 0;
+  }
+
+  const managedStatePath = resolveManagedPullRequestsStatePath(options.config.workdirRoot);
+  let managed: Array<{ repo: RepoInfo; prNumber: number; key: string }> = [];
+  try {
+    managed = await listManagedPullRequests(managedStatePath, { limit: 50 });
+  } catch (error) {
+    options.onLog?.("warn", "Managed PR catch-up scan failed to read state.", {
+      error: error instanceof Error ? error.message : String(error)
+    });
+    return 0;
+  }
+
+  if (managed.length === 0) {
+    return 0;
+  }
+
+  const reviewQueuePath = resolveReviewQueuePath(options.config.workdirRoot);
+  let enqueued = 0;
+  for (const entry of managed.slice().reverse()) {
+    if (enqueued >= limit) {
+      break;
+    }
+
+    let issue: IssueInfo | null;
+    try {
+      issue = await options.client.getIssue(entry.repo, entry.prNumber);
+    } catch (error) {
+      options.onLog?.("warn", "Managed PR catch-up scan failed to resolve issue.", {
+        pr: entry.key,
+        error: error instanceof Error ? error.message : String(error)
+      });
+      continue;
+    }
+    if (!issue || !issue.isPullRequest) {
+      continue;
+    }
+    if (
+      issue.labels.includes(options.config.labels.queued) ||
+      issue.labels.includes(options.config.labels.running) ||
+      issue.labels.includes(options.config.labels.needsUserReply) ||
+      issue.labels.includes(options.config.labels.failed)
+    ) {
+      continue;
+    }
+
+    if (!(await isManagedPullRequestIssue(issue, options.config))) {
+      continue;
+    }
+    await ensureManagedPullRequestRecorded(issue, options.config);
+
+    const pr = await options.client.getPullRequest(entry.repo, entry.prNumber);
+    if (!pr || pr.state !== "open" || pr.merged || pr.draft) {
+      continue;
+    }
+
+    try {
+      const threads = await options.client.listPullRequestReviewThreads(entry.repo, entry.prNumber);
+      const unresolved = threads.filter((thread) => !thread.isResolved);
+      if (unresolved.length > 0) {
+        if (options.dryRun) {
+          enqueued += 1;
+          continue;
+        }
+        const added = await enqueueReviewTask(reviewQueuePath, {
+          issueId: issue.id,
+          prNumber: entry.prNumber,
+          repo: entry.repo,
+          url: issue.url,
+          reason: "review_comment",
+          requiresEngine: true
+        });
+        if (added) {
+          enqueued += 1;
+        }
+        continue;
+      }
+    } catch (error) {
+      options.onLog?.("warn", "Managed PR catch-up scan failed to read review threads.", {
+        url: issue.url,
+        error: error instanceof Error ? error.message : String(error)
+      });
+      continue;
+    }
+
+    let reviews;
+    try {
+      reviews = await options.client.listPullRequestReviews(entry.repo, entry.prNumber);
+    } catch (error) {
+      options.onLog?.("warn", "Managed PR catch-up scan failed to read pull request reviews.", {
+        url: issue.url,
+        error: error instanceof Error ? error.message : String(error)
+      });
+      continue;
+    }
+
+    const summary = summarizeLatestReviews(
+      reviews.map((review) => ({
+        state: review.state,
+        author: review.author,
+        submittedAt: review.submittedAt,
+        body: review.body
+      })),
+      pr.requestedReviewerLogins
+    );
+
+    if (summary.changesRequested > 0 || summary.actionableComments > 0) {
+      if (options.dryRun) {
+        enqueued += 1;
+        continue;
+      }
+      const added = await enqueueReviewTask(reviewQueuePath, {
+        issueId: issue.id,
+        prNumber: entry.prNumber,
+        repo: entry.repo,
+        url: issue.url,
+        reason: "review",
+        requiresEngine: true
+      });
+      if (added) {
+        enqueued += 1;
+      }
+      continue;
+    }
+
+    if (summary.approved) {
+      if (options.dryRun) {
+        enqueued += 1;
+        continue;
+      }
+      const added = await enqueueReviewTask(reviewQueuePath, {
+        issueId: issue.id,
+        prNumber: entry.prNumber,
+        repo: entry.repo,
+        url: issue.url,
+        reason: "approval",
+        requiresEngine: false
+      });
+      if (added) {
+        enqueued += 1;
+      }
+    }
+  }
+
+  return enqueued;
+}
+

--- a/src/managed-pr-review-catchup.ts
+++ b/src/managed-pr-review-catchup.ts
@@ -3,7 +3,6 @@ import type { GitHubClient, IssueInfo, RepoInfo } from "./github.js";
 import { summarizeLatestReviews } from "./pr-review-automation.js";
 import { enqueueReviewTask, resolveReviewQueuePath } from "./review-queue.js";
 import { listManagedPullRequests, resolveManagedPullRequestsStatePath } from "./managed-pull-requests.js";
-import { ensureManagedPullRequestRecorded, isManagedPullRequestIssue } from "./managed-pr.js";
 
 export async function enqueueManagedPullRequestReviewFollowups(options: {
   client: GitHubClient;
@@ -63,11 +62,6 @@ export async function enqueueManagedPullRequestReviewFollowups(options: {
     ) {
       continue;
     }
-
-    if (!(await isManagedPullRequestIssue(issue, options.config))) {
-      continue;
-    }
-    await ensureManagedPullRequestRecorded(issue, options.config);
 
     const pr = await options.client.getPullRequest(entry.repo, entry.prNumber);
     if (!pr || pr.state !== "open" || pr.merged || pr.draft) {
@@ -164,4 +158,3 @@ export async function enqueueManagedPullRequestReviewFollowups(options: {
 
   return enqueued;
 }
-

--- a/src/managed-pr.ts
+++ b/src/managed-pr.ts
@@ -1,0 +1,44 @@
+import type { AgentRunnerConfig } from "./config.js";
+import type { IssueInfo } from "./github.js";
+import {
+  isManagedPullRequest as isManagedPullRequestState,
+  markManagedPullRequest,
+  resolveManagedPullRequestsStatePath
+} from "./managed-pull-requests.js";
+
+export function isAgentRunnerBotLogin(login: string | null): boolean {
+  if (!login) return false;
+  const normalized = login.trim().toLowerCase();
+  if (!normalized.endsWith("[bot]")) return false;
+  return normalized.includes("agent-runner");
+}
+
+export async function isManagedPullRequestIssue(issue: IssueInfo, config: AgentRunnerConfig): Promise<boolean> {
+  if (!issue.isPullRequest) {
+    return false;
+  }
+  if (isAgentRunnerBotLogin(issue.author ?? null)) {
+    return true;
+  }
+  const statePath = resolveManagedPullRequestsStatePath(config.workdirRoot);
+  return isManagedPullRequestState(statePath, issue.repo, issue.number);
+}
+
+export async function ensureManagedPullRequestRecorded(issue: IssueInfo, config: AgentRunnerConfig): Promise<boolean> {
+  if (!issue.isPullRequest) {
+    return false;
+  }
+
+  const statePath = resolveManagedPullRequestsStatePath(config.workdirRoot);
+  if (await isManagedPullRequestState(statePath, issue.repo, issue.number)) {
+    return true;
+  }
+
+  if (!isAgentRunnerBotLogin(issue.author ?? null)) {
+    return false;
+  }
+
+  await markManagedPullRequest(statePath, issue.repo, issue.number);
+  return true;
+}
+

--- a/src/pull-request-url.ts
+++ b/src/pull-request-url.ts
@@ -1,0 +1,30 @@
+import type { RepoInfo } from "./github.js";
+
+export type PullRequestUrlMatch = {
+  repo: RepoInfo;
+  number: number;
+  url: string;
+};
+
+export function parseLastPullRequestUrl(text: string): PullRequestUrlMatch | null {
+  let last: PullRequestUrlMatch | null = null;
+  const pattern = /https:\/\/github\.com\/([^/\s]+)\/([^/\s]+)\/pull\/(\d+)/gi;
+  for (const match of text.matchAll(pattern)) {
+    const number = Number.parseInt(match[3] ?? "", 10);
+    if (!Number.isFinite(number) || number <= 0) {
+      continue;
+    }
+    const owner = match[1] ?? "";
+    const repo = match[2] ?? "";
+    if (!owner || !repo) {
+      continue;
+    }
+    last = {
+      repo: { owner, repo },
+      number,
+      url: match[0] ?? ""
+    };
+  }
+  return last;
+}
+

--- a/src/review-scheduler.ts
+++ b/src/review-scheduler.ts
@@ -15,13 +15,18 @@ export function scheduleReviewFollowups(options: {
   if (spare <= 0) {
     return [];
   }
-  if (options.allowedEngines.length === 0) {
-    return [];
-  }
   const selected = options.queue.slice(0, spare);
+  if (options.allowedEngines.length === 0) {
+    return selected
+      .filter((entry) => !entry.requiresEngine)
+      .map((entry) => ({
+        ...entry,
+        engine: "codex"
+      }));
+  }
+
   return selected.map((entry, index) => ({
     ...entry,
     engine: options.allowedEngines[index % options.allowedEngines.length]
   }));
 }
-

--- a/src/webhook-handler.ts
+++ b/src/webhook-handler.ts
@@ -238,7 +238,14 @@ async function handleReviewFollowup(options: {
   if (!(await isManagedPullRequestIssue(issue, config))) {
     return;
   }
-  await ensureManagedPullRequestRecorded(issue, config);
+  try {
+    await ensureManagedPullRequestRecorded(issue, config);
+  } catch (error) {
+    onLog?.("warn", "Failed to record managed PR during review follow-up. Proceeding anyway.", {
+      url: issue.url,
+      error: error instanceof Error ? error.message : String(error)
+    });
+  }
 
   await safeRemoveLabel(client, issue, config.labels.needsUserReply, onLog);
   await safeRemoveLabel(client, issue, config.labels.failed, onLog);

--- a/tests/unit/managed-pr-review-catchup.test.ts
+++ b/tests/unit/managed-pr-review-catchup.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { AgentRunnerConfig } from "../../src/config.js";
+import type { IssueInfo, PullRequestDetails, RepoInfo } from "../../src/github.js";
+import { markManagedPullRequest, resolveManagedPullRequestsStatePath } from "../../src/managed-pull-requests.js";
+import { enqueueManagedPullRequestReviewFollowups } from "../../src/managed-pr-review-catchup.js";
+import { loadReviewQueue, resolveReviewQueuePath } from "../../src/review-queue.js";
+
+function makeConfig(workdirRoot: string): AgentRunnerConfig {
+  return {
+    owner: "metyatech",
+    repos: ["demo"],
+    workdirRoot,
+    pollIntervalSeconds: 60,
+    concurrency: 1,
+    labels: {
+      queued: "agent:queued",
+      running: "agent:running",
+      done: "agent:done",
+      failed: "agent:failed",
+      needsUserReply: "agent:needs-user-reply"
+    },
+    codex: { command: "codex", args: [], promptTemplate: "" },
+    idle: { enabled: true, maxRunsPerCycle: 1, cooldownMinutes: 60, tasks: [], promptTemplate: "" }
+  };
+}
+
+function makeRepo(): RepoInfo {
+  return { owner: "metyatech", repo: "demo" };
+}
+
+function makeIssue(repo: RepoInfo): IssueInfo {
+  return {
+    id: 101,
+    number: 5,
+    title: "PR",
+    body: "Body",
+    author: "metyatech",
+    repo,
+    labels: [],
+    url: "https://github.com/metyatech/demo/pull/5",
+    isPullRequest: true
+  };
+}
+
+function makePullRequestDetails(): PullRequestDetails {
+  return {
+    number: 5,
+    url: "https://github.com/metyatech/demo/pull/5",
+    draft: false,
+    state: "open",
+    merged: false,
+    mergeable: true,
+    mergeableState: "clean",
+    headRef: "refs/heads/feature",
+    headSha: "abc",
+    headRepoFullName: "metyatech/demo",
+    requestedReviewerLogins: []
+  };
+}
+
+describe("managed-pr-review-catchup", () => {
+  it("enqueues follow-ups for managed PRs even without agent:done label", async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "agent-runner-managed-pr-catchup-"));
+    const config = makeConfig(root);
+    const repo = makeRepo();
+    const issue = makeIssue(repo);
+
+    const managedStatePath = resolveManagedPullRequestsStatePath(config.workdirRoot);
+    await markManagedPullRequest(managedStatePath, repo, issue.number);
+
+    const client = {
+      getIssue: async () => issue,
+      getPullRequest: async () => makePullRequestDetails(),
+      listPullRequestReviewThreads: async () => [{ id: "t1", isResolved: false, isOutdated: false }],
+      listPullRequestReviews: async () => []
+    };
+
+    const enqueued = await enqueueManagedPullRequestReviewFollowups({
+      client: client as any,
+      config,
+      dryRun: false,
+      maxEntries: 5
+    });
+
+    expect(enqueued).toBe(1);
+    const queuePath = resolveReviewQueuePath(config.workdirRoot);
+    const queued = loadReviewQueue(queuePath);
+    expect(queued).toHaveLength(1);
+    expect(queued[0]?.reason).toBe("review_comment");
+    expect(queued[0]?.requiresEngine).toBe(true);
+  });
+});
+

--- a/tests/unit/managed-pr.test.ts
+++ b/tests/unit/managed-pr.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { AgentRunnerConfig } from "../../src/config.js";
+import type { IssueInfo } from "../../src/github.js";
+import { ensureManagedPullRequestRecorded, isManagedPullRequestIssue } from "../../src/managed-pr.js";
+import { markManagedPullRequest, resolveManagedPullRequestsStatePath } from "../../src/managed-pull-requests.js";
+
+function makeConfig(workdirRoot: string): AgentRunnerConfig {
+  return {
+    owner: "metyatech",
+    repos: ["demo"],
+    workdirRoot,
+    pollIntervalSeconds: 60,
+    concurrency: 1,
+    labels: {
+      queued: "agent:queued",
+      running: "agent:running",
+      done: "agent:done",
+      failed: "agent:failed",
+      needsUserReply: "agent:needs-user-reply"
+    },
+    codex: { command: "codex", args: [], promptTemplate: "" }
+  };
+}
+
+function makePullRequestIssue(options: { author: string | null; number?: number; id?: number }): IssueInfo {
+  return {
+    id: options.id ?? 101,
+    number: options.number ?? 5,
+    title: "PR",
+    body: "Body",
+    author: options.author,
+    repo: { owner: "metyatech", repo: "demo" },
+    labels: [],
+    url: "https://github.com/metyatech/demo/pull/5",
+    isPullRequest: true
+  };
+}
+
+describe("managed-pr", () => {
+  it("treats agent-runner bot-authored PRs as managed even when state is empty", async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "agent-runner-managed-pr-bot-"));
+    const config = makeConfig(root);
+    const issue = makePullRequestIssue({ author: "agent-runner-app[bot]" });
+    await expect(isManagedPullRequestIssue(issue, config)).resolves.toBe(true);
+  });
+
+  it("treats state-recorded PRs as managed even when author is not an agent-runner bot", async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "agent-runner-managed-pr-state-"));
+    const config = makeConfig(root);
+    const issue = makePullRequestIssue({ author: "metyatech" });
+    const statePath = resolveManagedPullRequestsStatePath(config.workdirRoot);
+    await markManagedPullRequest(statePath, issue.repo, issue.number);
+    await expect(isManagedPullRequestIssue(issue, config)).resolves.toBe(true);
+  });
+
+  it("records agent-runner bot-authored PRs into managed state", async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "agent-runner-managed-pr-record-"));
+    const config = makeConfig(root);
+    const issue = makePullRequestIssue({ author: "agent-runner-app[bot]" });
+    await expect(ensureManagedPullRequestRecorded(issue, config)).resolves.toBe(true);
+
+    const statePath = resolveManagedPullRequestsStatePath(config.workdirRoot);
+    const raw = fs.readFileSync(statePath, "utf8");
+    const parsed = JSON.parse(raw) as { managedPullRequests?: string[] };
+    expect(parsed.managedPullRequests ?? []).toContain("metyatech/demo#5");
+  });
+
+  it("does not record non-bot PRs when they are not already managed", async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "agent-runner-managed-pr-no-record-"));
+    const config = makeConfig(root);
+    const issue = makePullRequestIssue({ author: "metyatech" });
+    await expect(ensureManagedPullRequestRecorded(issue, config)).resolves.toBe(false);
+
+    const statePath = resolveManagedPullRequestsStatePath(config.workdirRoot);
+    expect(fs.existsSync(statePath)).toBe(false);
+  });
+});
+

--- a/tests/unit/pull-request-url.test.ts
+++ b/tests/unit/pull-request-url.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { parseLastPullRequestUrl } from "../../src/pull-request-url.js";
+
+describe("pull-request-url", () => {
+  it("returns null when no PR url is present", () => {
+    expect(parseLastPullRequestUrl("no link")).toBe(null);
+  });
+
+  it("parses the last GitHub PR URL in text", () => {
+    const text =
+      "first https://github.com/metyatech/demo/pull/1 and then https://github.com/metyatech/demo/pull/42";
+    expect(parseLastPullRequestUrl(text)).toEqual({
+      repo: { owner: "metyatech", repo: "demo" },
+      number: 42,
+      url: "https://github.com/metyatech/demo/pull/42"
+    });
+  });
+});
+

--- a/tests/unit/review-scheduler.test.ts
+++ b/tests/unit/review-scheduler.test.ts
@@ -36,5 +36,29 @@ describe("review-scheduler", () => {
     expect(scheduled[0].issueId).toBe(1);
     expect(scheduled[0].engine).toBe("codex");
   });
-});
 
+  it("schedules merge-only follow-ups even when no engines are allowed", () => {
+    const queue: ReviewQueueEntry[] = [
+      {
+        issueId: 1,
+        prNumber: 1,
+        repo: { owner: "metyatech", repo: "a" },
+        url: "x",
+        reason: "approval",
+        requiresEngine: false,
+        enqueuedAt: new Date().toISOString()
+      }
+    ];
+
+    const scheduled = scheduleReviewFollowups({
+      normalRunning: 0,
+      concurrency: 1,
+      allowedEngines: [],
+      queue
+    });
+
+    expect(scheduled).toHaveLength(1);
+    expect(scheduled[0].issueId).toBe(1);
+    expect(scheduled[0].engine).toBe("codex");
+  });
+});

--- a/tests/unit/setup-git-hooks.test.ts
+++ b/tests/unit/setup-git-hooks.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const scriptPath = path.resolve(process.cwd(), "scripts", "setup-git-hooks.mjs");
+
+function runNode(cwd: string) {
+  return spawnSync(process.execPath, [scriptPath], { cwd, encoding: "utf8" });
+}
+
+function runGit(cwd: string, args: string[]) {
+  const result = spawnSync("git", args, { cwd, encoding: "utf8" });
+  if (result.status !== 0) {
+    const stderr = (result.stderr ?? "").trim();
+    throw new Error(`git ${args.join(" ")} failed (status=${result.status}): ${stderr}`);
+  }
+  return (result.stdout ?? "").trim();
+}
+
+describe("setup-git-hooks script", () => {
+  it("exits successfully outside a git repo", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-runner-hooks-notgit-"));
+    const result = runNode(dir);
+    expect(result.status).toBe(0);
+  });
+
+  it("sets core.hooksPath to .githooks when missing", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-runner-hooks-set-"));
+    runGit(dir, ["init"]);
+
+    spawnSync("git", ["config", "--local", "--unset-all", "core.hooksPath"], { cwd: dir, encoding: "utf8" });
+    const before = spawnSync("git", ["config", "--local", "--get", "core.hooksPath"], { cwd: dir, encoding: "utf8" });
+    expect(before.status).not.toBe(0);
+
+    const result = runNode(dir);
+    expect(result.status).toBe(0);
+
+    expect(runGit(dir, ["config", "--local", "--get", "core.hooksPath"])).toBe(".githooks");
+    expect(fs.existsSync(path.join(dir, ".githooks"))).toBe(true);
+  });
+
+  it("does not override an existing core.hooksPath value", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-runner-hooks-nooverride-"));
+    runGit(dir, ["init"]);
+    runGit(dir, ["config", "--local", "core.hooksPath", ".custom-hooks"]);
+
+    const result = runNode(dir);
+    expect(result.status).toBe(0);
+
+    expect(runGit(dir, ["config", "--local", "--get", "core.hooksPath"])).toBe(".custom-hooks");
+  });
+});


### PR DESCRIPTION
## Summary
- Unify managed PR detection for review follow-ups across webhooks and catch-up scans.
- Record managed PRs earlier from /agent run catch-up and from idle/run summaries.

## Test Plan
- npm run verify