### PR TITLE
fix: manage GitHub App bot PRs

### DIFF
--- a/src/managed-pr-review-catchup.ts
+++ b/src/managed-pr-review-catchup.ts
@@ -1,5 +1,6 @@
 import type { AgentRunnerConfig } from "./config.js";
 import type { GitHubClient, IssueInfo, RepoInfo } from "./github.js";
+import { ensureManagedPullRequestRecorded, isManagedPullRequestIssue } from "./managed-pr.js";
 import { summarizeLatestReviews } from "./pr-review-automation.js";
 import { enqueueReviewTask, resolveReviewQueuePath } from "./review-queue.js";
 import { listManagedPullRequests, resolveManagedPullRequestsStatePath } from "./managed-pull-requests.js";
@@ -19,6 +20,13 @@ export async function enqueueManagedPullRequestReviewFollowups(options: {
     return 0;
   }
 
+  const excludeLabels = [
+    options.config.labels.queued,
+    options.config.labels.running,
+    options.config.labels.needsUserReply,
+    options.config.labels.failed
+  ];
+
   const managedStatePath = resolveManagedPullRequestsStatePath(options.config.workdirRoot);
   let managed: Array<{ repo: RepoInfo; prNumber: number; key: string }> = [];
   try {
@@ -27,16 +35,54 @@ export async function enqueueManagedPullRequestReviewFollowups(options: {
     options.onLog?.("warn", "Managed PR catch-up scan failed to read state.", {
       error: error instanceof Error ? error.message : String(error)
     });
-    return 0;
   }
 
-  if (managed.length === 0) {
+  const candidates: Array<{ repo: RepoInfo; prNumber: number; key: string }> = [];
+  const seen = new Set<string>();
+  for (const entry of managed.slice().reverse()) {
+    if (seen.has(entry.key)) {
+      continue;
+    }
+    seen.add(entry.key);
+    candidates.push(entry);
+  }
+
+  const botAuthorLogins = ["agent-runner-bot", "app/agent-runner-bot", "agent-runner-app[bot]"];
+  for (const login of botAuthorLogins) {
+    let found: IssueInfo[] = [];
+    try {
+      found = await options.client.searchOpenPullRequestsByAuthorAcrossOwner(options.config.owner, login, {
+        excludeLabels,
+        perPage: 100,
+        maxPages: 1
+      });
+    } catch (error) {
+      options.onLog?.("warn", "Managed PR catch-up scan failed to search for agent-runner bot PRs.", {
+        author: login,
+        error: error instanceof Error ? error.message : String(error)
+      });
+      continue;
+    }
+    for (const item of found) {
+      if (!item.isPullRequest) {
+        continue;
+      }
+      const key = `${item.repo.owner.toLowerCase()}/${item.repo.repo.toLowerCase()}#${item.number}`;
+      if (seen.has(key)) {
+        continue;
+      }
+      seen.add(key);
+      candidates.push({ repo: item.repo, prNumber: item.number, key });
+    }
+  }
+
+  if (candidates.length === 0) {
     return 0;
   }
 
   const reviewQueuePath = resolveReviewQueuePath(options.config.workdirRoot);
   let enqueued = 0;
-  for (const entry of managed.slice().reverse()) {
+  for (const entry of candidates) {
     if (enqueued >= limit) {
       break;
     }
@@ -53,6 +99,17 @@ export async function enqueueManagedPullRequestReviewFollowups(options: {
     }
     if (!issue || !issue.isPullRequest) {
       continue;
+    }
+    if (!(await isManagedPullRequestIssue(issue, options.config))) {
+      continue;
+    }
+    try {
+      await ensureManagedPullRequestRecorded(issue, options.config);
+    } catch (error) {
+      options.onLog?.("warn", "Managed PR catch-up scan failed to record managed PR state.", {
+        url: issue.url,
+        error: error instanceof Error ? error.message : String(error)
+      });
     }
     if (
       issue.labels.includes(options.config.labels.queued) ||

--- a/src/managed-pr.ts
+++ b/src/managed-pr.ts
@@ -8,9 +8,10 @@ import {
 
 export function isAgentRunnerBotLogin(login: string | null): boolean {
   if (!login) return false;
-  const normalized = login.trim().toLowerCase();
-  if (!normalized.endsWith("[bot]")) return false;
-  return normalized.includes("agent-runner");
+  const trimmed = login.trim().toLowerCase();
+  const normalized = trimmed.startsWith("app/") ? trimmed.slice("app/".length) : trimmed;
+  if (!normalized.includes("agent-runner")) return false;
+  return normalized.endsWith("[bot]") || normalized.endsWith("-bot");
 }
 
 export async function isManagedPullRequestIssue(issue: IssueInfo, config: AgentRunnerConfig): Promise<boolean> {
@@ -41,4 +42,3 @@ export async function ensureManagedPullRequestRecorded(issue: IssueInfo, config:
   await markManagedPullRequest(statePath, issue.repo, issue.number);
   return true;
 }
-

--- a/src/managed-pr.ts
+++ b/src/managed-pr.ts
@@ -10,8 +10,11 @@ export function isAgentRunnerBotLogin(login: string | null): boolean {
   if (!login) return false;
   const trimmed = login.trim().toLowerCase();
   const normalized = trimmed.startsWith("app/") ? trimmed.slice("app/".length) : trimmed;
-  if (!normalized.includes("agent-runner")) return false;
-  return normalized.endsWith("[bot]") || normalized.endsWith("-bot");
+  if (normalized.endsWith("[bot]")) {
+    return normalized.includes("agent-runner");
+  }
+
+  return normalized === "agent-runner-bot";
 }
 
 export async function isManagedPullRequestIssue(issue: IssueInfo, config: AgentRunnerConfig): Promise<boolean> {

--- a/tests/unit/managed-pr.test.ts
+++ b/tests/unit/managed-pr.test.ts
@@ -47,6 +47,13 @@ describe("managed-pr", () => {
     await expect(isManagedPullRequestIssue(issue, config)).resolves.toBe(true);
   });
 
+  it("treats agent-runner GitHub App bot-authored PRs as managed even when state is empty", async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "agent-runner-managed-pr-app-bot-"));
+    const config = makeConfig(root);
+    await expect(isManagedPullRequestIssue(makePullRequestIssue({ author: "agent-runner-bot" }), config)).resolves.toBe(true);
+    await expect(isManagedPullRequestIssue(makePullRequestIssue({ author: "app/agent-runner-bot" }), config)).resolves.toBe(true);
+  });
+
   it("treats state-recorded PRs as managed even when author is not an agent-runner bot", async () => {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), "agent-runner-managed-pr-state-"));
     const config = makeConfig(root);
@@ -78,4 +85,3 @@ describe("managed-pr", () => {
     expect(fs.existsSync(statePath)).toBe(false);
   });
 });
-


### PR DESCRIPTION
Fix managed PR detection for GitHub App bot authors (e.g. agent-runner-bot / app/agent-runner-bot) and ensure managed PR review catch-up discovers these PRs even when local managed state is empty.

- Treat agent-runner App bot logins as managed
- Add catch-up discovery via GitHub search for agent-runner bot-authored open PRs
- Add regression tests