### PR TITLE
feat: notify on idle-created PRs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,6 @@ state/
 git-cache/
 work/
 .githooks/
+.custom-hooks/
 .env
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -327,7 +327,11 @@ Helper script (writes `state/github-notify-token.txt`):
 .\scripts\set-notify-token.ps1 -Token "<token>"
 ```
 
-For idle runs, notifications are posted to the PR when a PR URL is present in the idle summary.
+For idle runs that create a PR, agent-runner will try to locate the PR URL from the idle summary or the idle log tail.
+If no PR URL is available, it will fall back to searching for an open PR by the idle run's head branch.
+When a PR is detected, agent-runner assigns the authenticated user of the runner GitHub token to the PR (to trigger GitHub notifications)
+and posts an idle completion comment. If a notify client is configured, the comment is posted as the notify identity; otherwise it is posted
+using the runner token.
 If `idle.repoScope` is set to `"local"`, idle runs only target repositories under the workspace root.
 If `idle.usageGate.enabled` is true, idle runs only execute when the weekly reset
 window is near and unused weekly capacity remains. The weekly threshold ramps

--- a/README.md
+++ b/README.md
@@ -329,7 +329,7 @@ Helper script (writes `state/github-notify-token.txt`):
 
 For idle runs that create a PR, agent-runner will try to locate the PR URL from the idle summary or the idle log tail.
 If no PR URL is available, it will fall back to searching for an open PR by the idle run's head branch.
-When a PR is detected, agent-runner assigns the authenticated user of the runner GitHub token to the PR (to trigger GitHub notifications)
+When a PR is detected, agent-runner assigns the authenticated user associated with the runner GitHub token to the PR (to trigger GitHub notifications)
 and posts an idle completion comment. If a notify client is configured, the comment is posted as the notify identity; otherwise it is posted
 using the runner token.
 If `idle.repoScope` is set to `"local"`, idle runs only target repositories under the workspace root.

--- a/src/github.ts
+++ b/src/github.ts
@@ -832,12 +832,12 @@ export class GitHubClient {
     }
   }
 
-  async findOpenPullRequestByHead(repo: RepoInfo, headRef: string): Promise<{ number: number; url: string } | null> {
+  async findOpenPullRequestByHead(repo: RepoInfo, headBranch: string): Promise<{ number: number; url: string } | null> {
     const response = await this.octokit.pulls.list({
       owner: repo.owner,
       repo: repo.repo,
       state: "open",
-      head: `${repo.owner}:${headRef}`,
+      head: `${repo.owner}:${headBranch}`,
       per_page: 10,
       page: 1
     });

--- a/src/github.ts
+++ b/src/github.ts
@@ -838,7 +838,7 @@ export class GitHubClient {
       repo: repo.repo,
       state: "open",
       head: `${repo.owner}:${headBranch}`,
-      per_page: 10,
+      per_page: 1,
       page: 1
     });
     const first = response.data[0];

--- a/src/idle-pr-notify.ts
+++ b/src/idle-pr-notify.ts
@@ -85,14 +85,22 @@ export async function notifyIdlePullRequest(options: {
   } else if (prFromLog) {
     pr = { ...prFromLog, source: "log" };
   } else if (options.result.headBranch) {
-    const found = await options.client.findOpenPullRequestByHead(options.result.repo, options.result.headBranch);
-    if (found) {
-      pr = {
-        repo: options.result.repo,
-        number: found.number,
-        url: found.url,
-        source: "head"
-      };
+    try {
+      const found = await options.client.findOpenPullRequestByHead(options.result.repo, options.result.headBranch);
+      if (found) {
+        pr = {
+          repo: options.result.repo,
+          number: found.number,
+          url: found.url,
+          source: "head"
+        };
+      }
+    } catch (error) {
+      options.log("warn", "Failed to locate idle PR by head branch; skipping.", options.json, {
+        repo: `${options.result.repo.owner}/${options.result.repo.repo}`,
+        headBranch: options.result.headBranch,
+        error: error instanceof Error ? error.message : String(error)
+      });
     }
   }
 

--- a/src/idle-pr-notify.ts
+++ b/src/idle-pr-notify.ts
@@ -26,8 +26,14 @@ export async function notifyIdlePullRequest(options: {
   const isSameRepo = (left: RepoInfo, right: RepoInfo): boolean =>
     left.owner.toLowerCase() === right.owner.toLowerCase() && left.repo.toLowerCase() === right.repo.toLowerCase();
 
-  const truncate = (value: string, limit: number): string =>
-    value.length <= limit ? value : `${value.slice(0, Math.max(0, limit - 16))}\n…(truncated)…`;
+  const truncate = (value: string, limit: number): string => {
+    const suffix = "\n…(truncated)…";
+    if (value.length <= limit) {
+      return value;
+    }
+    const sliceLength = Math.max(0, limit - suffix.length);
+    return `${value.slice(0, sliceLength)}${suffix}`;
+  };
 
   const readLogTail = (logPath: string, maxBytes: number): string | null => {
     if (!fs.existsSync(logPath)) {

--- a/src/idle-pr-notify.ts
+++ b/src/idle-pr-notify.ts
@@ -1,0 +1,141 @@
+import fs from "node:fs";
+
+import type { AgentRunnerConfig } from "./config.js";
+import type { GitHubClient, RepoInfo } from "./github.js";
+import { ensureManagedPullRequestRecorded } from "./managed-pr.js";
+import { buildAgentComment } from "./notifications.js";
+import { parseLastPullRequestUrl } from "./pull-request-url.js";
+import type { IdleTaskResult } from "./runner.js";
+
+export type IdlePullRequestNotification = {
+  repo: RepoInfo;
+  number: number;
+  url: string;
+  source: "summary" | "log" | "head";
+};
+
+export async function notifyIdlePullRequest(options: {
+  client: GitHubClient;
+  notifyClient: GitHubClient | null;
+  config: AgentRunnerConfig;
+  result: IdleTaskResult;
+  json: boolean;
+  log: (level: "info" | "warn" | "error", message: string, json: boolean, meta?: Record<string, unknown>) => void;
+}): Promise<IdlePullRequestNotification | null> {
+  const truncate = (value: string, limit: number): string =>
+    value.length <= limit ? value : `${value.slice(0, Math.max(0, limit - 16))}\n…(truncated)…`;
+
+  const readLogTail = (logPath: string, maxBytes: number): string | null => {
+    if (!fs.existsSync(logPath)) {
+      return null;
+    }
+    try {
+      const stat = fs.statSync(logPath);
+      const size = stat.size;
+      if (size <= maxBytes) {
+        return fs.readFileSync(logPath, "utf8");
+      }
+
+      const fd = fs.openSync(logPath, "r");
+      try {
+        const buffer = Buffer.allocUnsafe(maxBytes);
+        const offset = Math.max(0, size - maxBytes);
+        const bytesRead = fs.readSync(fd, buffer, 0, maxBytes, offset);
+        return buffer.subarray(0, bytesRead).toString("utf8");
+      } finally {
+        fs.closeSync(fd);
+      }
+    } catch {
+      return null;
+    }
+  };
+
+  const summaryText = options.result.summary ?? "";
+  const prFromSummary = parseLastPullRequestUrl(summaryText);
+  const prFromLog = prFromSummary
+    ? null
+    : parseLastPullRequestUrl(readLogTail(options.result.logPath, 512 * 1024) ?? "");
+
+  let pr: IdlePullRequestNotification | null = null;
+  if (prFromSummary) {
+    pr = { ...prFromSummary, source: "summary" };
+  } else if (prFromLog) {
+    pr = { ...prFromLog, source: "log" };
+  } else if (options.result.headBranch) {
+    const found = await options.client.findOpenPullRequestByHead(options.result.repo, options.result.headBranch);
+    if (found) {
+      pr = {
+        repo: options.result.repo,
+        number: found.number,
+        url: found.url,
+        source: "head"
+      };
+    }
+  }
+
+  if (!pr) {
+    return null;
+  }
+
+  try {
+    const prIssue = await options.client.getIssue(pr.repo, pr.number);
+    if (prIssue) {
+      await ensureManagedPullRequestRecorded(prIssue, options.config);
+    }
+  } catch (error) {
+    options.log("warn", "Failed to record managed PR from idle PR notification.", options.json, {
+      pr: pr.url,
+      error: error instanceof Error ? error.message : String(error)
+    });
+  }
+
+  const authLogin = await options.client.getAuthenticatedLogin();
+  if (authLogin) {
+    try {
+      await options.client.addAssignees(pr.repo, pr.number, [authLogin]);
+    } catch (error) {
+      options.log("warn", "Failed to assign idle PR to authenticated user.", options.json, {
+        pr: pr.url,
+        assignee: authLogin,
+        error: error instanceof Error ? error.message : String(error)
+      });
+    }
+  }
+
+  const mentionLine = authLogin ? `Notify: @${authLogin}\n` : "";
+  const body = buildAgentComment(
+    `Agent runner idle ${options.result.success ? "completed" : "failed"}.\n\n` +
+      `Repo: ${options.result.repo.owner}/${options.result.repo.repo}\n` +
+      `Engine: ${options.result.engine}\n` +
+      mentionLine +
+      `\nSummary:\n${truncate(summaryText || "(missing)", 6000)}`
+  );
+
+  const postComment = async (client: GitHubClient): Promise<void> => {
+    await client.commentIssue(pr.repo, pr.number, body);
+  };
+
+  if (options.notifyClient) {
+    try {
+      await postComment(options.notifyClient);
+      return pr;
+    } catch (error) {
+      options.log("warn", "Failed to post idle completion comment with notify client; falling back.", options.json, {
+        pr: pr.url,
+        error: error instanceof Error ? error.message : String(error)
+      });
+    }
+  }
+
+  try {
+    await postComment(options.client);
+  } catch (error) {
+    options.log("warn", "Failed to post idle completion comment to PR.", options.json, {
+      pr: pr.url,
+      error: error instanceof Error ? error.message : String(error)
+    });
+  }
+
+  return pr;
+}
+

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -61,6 +61,7 @@ export type IdleTaskResult = {
   engine: IdleEngine;
   summary: string | null;
   reportPath: string;
+  headBranch: string;
 };
 
 export type EngineInvocation = {
@@ -1053,7 +1054,8 @@ export async function runIdleTask(
     task,
     engine,
     summary,
-    reportPath
+    reportPath,
+    headBranch: newBranch
   };
   } finally {
     if (created) {

--- a/tests/unit/github-auth-assignee.test.ts
+++ b/tests/unit/github-auth-assignee.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import { GitHubClient } from "../../src/github.js";
+
+describe("GitHubClient.getAuthenticatedLogin", () => {
+  it("returns authenticated user login", async () => {
+    const client = new GitHubClient("dummy");
+    (client as any).octokit = {
+      users: {
+        getAuthenticated: async () => ({
+          data: { login: "alice" }
+        })
+      }
+    };
+
+    await expect(client.getAuthenticatedLogin()).resolves.toBe("alice");
+  });
+});
+
+describe("GitHubClient.addAssignees", () => {
+  it("filters empty assignees and calls issues.addAssignees", async () => {
+    const client = new GitHubClient("dummy");
+    let seen: any = null;
+    (client as any).octokit = {
+      issues: {
+        addAssignees: async (params: any) => {
+          seen = params;
+          return { data: {} };
+        }
+      }
+    };
+
+    await client.addAssignees({ owner: "metyatech", repo: "demo" }, 123, ["alice", " ", "alice"]);
+
+    expect(seen).toMatchObject({
+      owner: "metyatech",
+      repo: "demo",
+      issue_number: 123,
+      assignees: ["alice"]
+    });
+  });
+});
+
+describe("GitHubClient.findOpenPullRequestByHead", () => {
+  it("passes owner:branch to pulls.list and returns the first PR", async () => {
+    const client = new GitHubClient("dummy");
+    let seen: any = null;
+    (client as any).octokit = {
+      pulls: {
+        list: async (params: any) => {
+          seen = params;
+          return {
+            data: [
+              {
+                number: 7,
+                html_url: "https://github.com/metyatech/demo/pull/7"
+              }
+            ]
+          };
+        }
+      }
+    };
+
+    await expect(
+      client.findOpenPullRequestByHead({ owner: "metyatech", repo: "demo" }, "agent-runner/idle-codex-123")
+    ).resolves.toEqual({
+      number: 7,
+      url: "https://github.com/metyatech/demo/pull/7"
+    });
+
+    expect(seen).toMatchObject({
+      owner: "metyatech",
+      repo: "demo",
+      state: "open",
+      head: "metyatech:agent-runner/idle-codex-123"
+    });
+  });
+});
+

--- a/tests/unit/idle-pr-notify.test.ts
+++ b/tests/unit/idle-pr-notify.test.ts
@@ -1,0 +1,137 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { notifyIdlePullRequest } from "../../src/idle-pr-notify.js";
+
+function createTempLog(contents: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-runner-"));
+  const logPath = path.join(dir, "idle.log");
+  fs.writeFileSync(logPath, contents, "utf8");
+  return logPath;
+}
+
+describe("notifyIdlePullRequest", () => {
+  it("assigns the authenticated user and posts a comment (summary URL)", async () => {
+    const calls: any = { addAssignees: [], commentIssue: [] };
+    const client: any = {
+      getAuthenticatedLogin: async () => "alice",
+      getIssue: async () => null,
+      addAssignees: async (repo: any, issueNumber: number, assignees: string[]) => {
+        calls.addAssignees.push({ repo, issueNumber, assignees });
+      },
+      commentIssue: async (repo: any, issueNumber: number, body: string) => {
+        calls.commentIssue.push({ repo, issueNumber, body });
+      },
+      findOpenPullRequestByHead: async () => null
+    };
+
+    const logPath = createTempLog("nothing");
+    const result: any = {
+      success: true,
+      logPath,
+      repo: { owner: "metyatech", repo: "demo" },
+      task: "T",
+      engine: "codex",
+      summary: "Done https://github.com/metyatech/demo/pull/123",
+      reportPath: "report.json",
+      headBranch: "agent-runner/idle-codex-123"
+    };
+
+    const notified = await notifyIdlePullRequest({
+      client,
+      notifyClient: null,
+      config: { workdirRoot: "D:/tmp" } as any,
+      result,
+      json: false,
+      log: () => {}
+    });
+
+    expect(notified?.number).toBe(123);
+    expect(calls.addAssignees).toHaveLength(1);
+    expect(calls.addAssignees[0]).toMatchObject({ issueNumber: 123, assignees: ["alice"] });
+    expect(calls.commentIssue).toHaveLength(1);
+    expect(calls.commentIssue[0].body).toContain("@alice");
+  });
+
+  it("extracts PR URL from log tail when summary is missing", async () => {
+    const calls: any = { commentIssue: [] };
+    const client: any = {
+      getAuthenticatedLogin: async () => null,
+      getIssue: async () => null,
+      addAssignees: async () => {},
+      commentIssue: async (repo: any, issueNumber: number, body: string) => {
+        calls.commentIssue.push({ repo, issueNumber, body });
+      },
+      findOpenPullRequestByHead: async () => null
+    };
+
+    const logPath = createTempLog("Created https://github.com/metyatech/demo/pull/9\n");
+    const result: any = {
+      success: true,
+      logPath,
+      repo: { owner: "metyatech", repo: "demo" },
+      task: "T",
+      engine: "codex",
+      summary: null,
+      reportPath: "report.json",
+      headBranch: "agent-runner/idle-codex-123"
+    };
+
+    const notified = await notifyIdlePullRequest({
+      client,
+      notifyClient: null,
+      config: { workdirRoot: "D:/tmp" } as any,
+      result,
+      json: false,
+      log: () => {}
+    });
+
+    expect(notified?.number).toBe(9);
+    expect(calls.commentIssue).toHaveLength(1);
+  });
+
+  it("falls back to searching by head branch when no URL is available", async () => {
+    const calls: any = { commentIssue: [] };
+    const client: any = {
+      getAuthenticatedLogin: async () => null,
+      getIssue: async () => null,
+      addAssignees: async () => {},
+      commentIssue: async (repo: any, issueNumber: number, body: string) => {
+        calls.commentIssue.push({ repo, issueNumber, body });
+      },
+      findOpenPullRequestByHead: async () => ({ number: 42, url: "https://github.com/metyatech/demo/pull/42" })
+    };
+
+    const logPath = path.join(os.tmpdir(), "agent-runner-missing.log");
+    try {
+      fs.rmSync(logPath, { force: true });
+    } catch {
+      // ignore
+    }
+
+    const result: any = {
+      success: true,
+      logPath,
+      repo: { owner: "metyatech", repo: "demo" },
+      task: "T",
+      engine: "codex",
+      summary: null,
+      reportPath: "report.json",
+      headBranch: "agent-runner/idle-codex-123"
+    };
+
+    const notified = await notifyIdlePullRequest({
+      client,
+      notifyClient: null,
+      config: { workdirRoot: "D:/tmp" } as any,
+      result,
+      json: false,
+      log: () => {}
+    });
+
+    expect(notified?.number).toBe(42);
+    expect(calls.commentIssue).toHaveLength(1);
+  });
+});
+


### PR DESCRIPTION
## Summary
- Improve idle-created PR notifications: assign PR to the runner's authenticated GitHub user and post an idle completion comment.
- PR detection: summary URL -> log tail -> head-branch search fallback.
- No longer requires a notify client for idle PR notifications (still preferred when configured).

## Acceptance Criteria
- AC1: When idle creates a PR, assign the authenticated runner user as an assignee.
- AC2: Idle PR notification works even without AGENT_GITHUB_NOTIFY_TOKEN / Notify App.
- AC3: If no PR URL is present, find the PR by the idle head branch.

## Verification
- npm run verify