### PR TITLE
Fix review follow-up failure on PR head branch resolution

### DIFF
--- a/src/git-worktree.ts
+++ b/src/git-worktree.ts
@@ -60,6 +60,14 @@ async function resolveBranchStartRef(cachePath: string, branch: string): Promise
   throw new Error(`Unable to resolve branch ${branch} in cache repo ${cachePath}`);
 }
 
+function buildRemoteBranchRef(branch: string): string {
+  return `refs/remotes/origin/${branch}`;
+}
+
+function buildBranchFetchRefspec(branch: string): string {
+  return `+refs/heads/${branch}:${buildRemoteBranchRef(branch)}`;
+}
+
 export async function ensureRepoCache(workdirRoot: string, repo: RepoInfo): Promise<string> {
   const cachePath = resolveRepoCachePath(workdirRoot, repo);
   if (fs.existsSync(cachePath)) {
@@ -145,6 +153,7 @@ export async function createWorktreeFromDefaultBranch(options: {
 }): Promise<void> {
   fs.mkdirSync(path.dirname(options.worktreePath), { recursive: true });
   await ensureDirAbsent(options.worktreePath);
+  fs.mkdirSync(options.worktreePath, { recursive: true });
 
   await withGitCacheLock(
     options.workdirRoot,
@@ -181,22 +190,20 @@ export async function createWorktreeForRemoteBranch(options: {
 }): Promise<void> {
   fs.mkdirSync(path.dirname(options.worktreePath), { recursive: true });
   await ensureDirAbsent(options.worktreePath);
+  fs.mkdirSync(options.worktreePath, { recursive: true });
 
   await withGitCacheLock(
     options.workdirRoot,
     options.repo,
     async () => {
       const env = buildAuthEnv();
-      await runCommand("git", ["-C", options.cachePath, "fetch", "--prune", "origin", options.branch], { env });
+      await runCommand(
+        "git",
+        ["-C", options.cachePath, "fetch", "--prune", "origin", buildBranchFetchRefspec(options.branch)],
+        { env }
+      );
       const startRef = await resolveBranchStartRef(options.cachePath, options.branch);
       await runCommand("git", ["-C", options.cachePath, "branch", "-f", options.branch, startRef], { env });
-      if (startRef.startsWith("refs/remotes/origin/")) {
-        await runCommand(
-          "git",
-          ["-C", options.cachePath, "branch", "--set-upstream-to", `origin/${options.branch}`, options.branch],
-          { env }
-        );
-      }
       await runCommand("git", ["-C", options.cachePath, "worktree", "add", options.worktreePath, options.branch], { env });
     },
     { timeoutMs: 15 * 60 * 1000 }

--- a/src/git-worktree.ts
+++ b/src/git-worktree.ts
@@ -153,7 +153,6 @@ export async function createWorktreeFromDefaultBranch(options: {
 }): Promise<void> {
   fs.mkdirSync(path.dirname(options.worktreePath), { recursive: true });
   await ensureDirAbsent(options.worktreePath);
-  fs.mkdirSync(options.worktreePath, { recursive: true });
 
   await withGitCacheLock(
     options.workdirRoot,
@@ -190,7 +189,6 @@ export async function createWorktreeForRemoteBranch(options: {
 }): Promise<void> {
   fs.mkdirSync(path.dirname(options.worktreePath), { recursive: true });
   await ensureDirAbsent(options.worktreePath);
-  fs.mkdirSync(options.worktreePath, { recursive: true });
 
   await withGitCacheLock(
     options.workdirRoot,

--- a/tests/unit/git-worktree.test.ts
+++ b/tests/unit/git-worktree.test.ts
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { RepoInfo } from "../../src/github.js";
+
+describe("git-worktree", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it("fetches PR head branch into refs/remotes/origin via explicit refspec", async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "agent-runner-git-worktree-"));
+    const repo: RepoInfo = { owner: "metyatech", repo: "demo" };
+    const worktreePath = path.join(root, "agent-runner", "work", "test-run", "metyatech--demo");
+    const cachePath = path.join(root, "agent-runner", "git-cache", repo.owner, `${repo.repo}.git`);
+    fs.mkdirSync(cachePath, { recursive: true });
+    const runCommandMock = vi.fn(async (_command: string, args: string[]) => {
+      const candidate = args.at(-1);
+      const isShowRef =
+        args.length >= 7 &&
+        args[2] === "show-ref" &&
+        args[3] === "--verify" &&
+        args[4] === "--quiet";
+      if (isShowRef && candidate === "refs/remotes/origin/compliance-fix") {
+        return "";
+      }
+      if (isShowRef) {
+        throw new Error("ref not found");
+      }
+      return "";
+    });
+    vi.doMock("../../src/git.js", () => ({ runCommand: runCommandMock }));
+    const { createWorktreeForRemoteBranch } = await import("../../src/git-worktree.js");
+
+    try {
+      await createWorktreeForRemoteBranch({
+        workdirRoot: root,
+        repo,
+        cachePath,
+        worktreePath,
+        branch: "compliance-fix"
+      });
+
+      const fetchCall = runCommandMock.mock.calls.find(
+        (call) => call[1][2] === "fetch" && call[1][3] === "--prune"
+      );
+      expect(fetchCall?.[1]).toEqual([
+        "-C",
+        cachePath,
+        "fetch",
+        "--prune",
+        "origin",
+        "+refs/heads/compliance-fix:refs/remotes/origin/compliance-fix"
+      ]);
+      expect(runCommandMock).toHaveBeenCalledWith(
+        "git",
+        ["-C", cachePath, "show-ref", "--verify", "--quiet", "refs/remotes/origin/compliance-fix"],
+        expect.objectContaining({ env: expect.any(Object) })
+      );
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+      vi.doUnmock("../../src/git.js");
+    }
+  });
+});

--- a/tests/unit/git-worktree.test.ts
+++ b/tests/unit/git-worktree.test.ts
@@ -18,7 +18,8 @@ describe("git-worktree", () => {
     const runCommandMock = vi.fn(async (_command: string, args: string[]) => {
       const candidate = args.at(-1);
       const isShowRef =
-        args.length >= 7 &&
+        args.length >= 6 &&
+        args[0] === "-C" &&
         args[2] === "show-ref" &&
         args[3] === "--verify" &&
         args[4] === "--quiet";


### PR DESCRIPTION
## Summary
- fix createWorktreeForRemoteBranch to fetch PR head branches with an explicit refspec into efs/remotes/origin/<branch> in the bare cache
- remove unnecessary upstream-tracking setup in the bare cache flow
- add a regression test for the fetch command to prevent Unable to resolve branch <name> in cache repo ... failures

## Test Plan
- [x] npm run verify
- [x] npm test -- --run tests/unit/git-worktree.test.ts